### PR TITLE
Obfuscate output shortened url using hashids.

### DIFF
--- a/egov-url-shortening/pom.xml
+++ b/egov-url-shortening/pom.xml
@@ -82,7 +82,13 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
-		
+		<!-- https://mvnrepository.com/artifact/org.hashids/hashids -->
+		<dependency>
+			<groupId>org.hashids</groupId>
+			<artifactId>hashids</artifactId>
+			<version>1.0.3</version>
+		</dependency>
+
 	</dependencies>
 	<repositories>
 		<repository>

--- a/egov-url-shortening/src/main/java/org/egov/url/shortening/service/URLConverterService.java
+++ b/egov-url-shortening/src/main/java/org/egov/url/shortening/service/URLConverterService.java
@@ -86,7 +86,12 @@ public class URLConverterService {
     }
 
     public String getLongURLFromID(String uniqueID) throws Exception {
-        Long dictionaryKey = hashIdConverter.getIdForString(uniqueID);
+        Long dictionaryKey;
+        try {
+            dictionaryKey = hashIdConverter.getIdForString(uniqueID);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            dictionaryKey = IDConvertor.getDictionaryKeyFromUniqueID(uniqueID);
+        }
         String longUrl = urlRepository.getUrl(dictionaryKey);
         LOGGER.info("Converting shortened URL back to {}", longUrl);
         if(longUrl.isEmpty())

--- a/egov-url-shortening/src/main/java/org/egov/url/shortening/service/URLConverterService.java
+++ b/egov-url-shortening/src/main/java/org/egov/url/shortening/service/URLConverterService.java
@@ -7,6 +7,7 @@ import javax.annotation.PostConstruct;
 import org.egov.tracer.model.CustomException;
 import org.egov.url.shortening.model.ShortenRequest;
 import org.egov.url.shortening.repository.URLRepository;
+import org.egov.url.shortening.utils.HashIdConverter;
 import org.egov.url.shortening.utils.IDConvertor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,9 @@ public class URLConverterService {
     
     @Value("${server.contextPath}")
     private String serverContextPath;
+
+    @Autowired
+    private HashIdConverter hashIdConverter;
     
     private ObjectMapper objectMapper;
 
@@ -59,7 +63,7 @@ public class URLConverterService {
     public String shortenURL(ShortenRequest shortenRequest) {
         LOGGER.info("Shortening {}", shortenRequest.getUrl());
         Long id = urlRepository.incrementID();
-        String uniqueID = IDConvertor.createUniqueID(id);
+        String uniqueID = hashIdConverter.createHashStringForId(id);
         try {
 			urlRepository.saveUrl("url:"+id, shortenRequest);
 		} catch (JsonProcessingException e) {
@@ -82,7 +86,7 @@ public class URLConverterService {
     }
 
     public String getLongURLFromID(String uniqueID) throws Exception {
-        Long dictionaryKey = IDConvertor.getDictionaryKeyFromUniqueID(uniqueID);
+        Long dictionaryKey = hashIdConverter.getIdForString(uniqueID);
         String longUrl = urlRepository.getUrl(dictionaryKey);
         LOGGER.info("Converting shortened URL back to {}", longUrl);
         if(longUrl.isEmpty())

--- a/egov-url-shortening/src/main/java/org/egov/url/shortening/utils/HashIdConverter.java
+++ b/egov-url-shortening/src/main/java/org/egov/url/shortening/utils/HashIdConverter.java
@@ -1,0 +1,32 @@
+package org.egov.url.shortening.utils;
+
+import org.hashids.Hashids;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+public class HashIdConverter {
+
+    @Value("${hashids.salt}")
+    private String salt;
+    @Value("${hsahids.min.length}")
+    private Integer minimumLength;
+
+    private Hashids hashids;
+
+    @PostConstruct
+    public void init() {
+        hashids = new Hashids(salt, minimumLength);
+    }
+
+    public String createHashStringForId(Long id) {
+        return hashids.encode(id);
+    }
+
+    public Long getIdForString(String string) {
+        return hashids.decode(string)[0];
+    }
+
+}

--- a/egov-url-shortening/src/main/resources/application.properties
+++ b/egov-url-shortening/src/main/resources/application.properties
@@ -23,4 +23,7 @@ flyway.enabled=true
 
 db.persistance.enabled=true
 
-host.name=https://egov-micro-qa.egovernments.org/
+host.name=http://localhost:8091/
+
+hashids.salt=randomsalt
+hsahids.min.length=3


### PR DESCRIPTION
This enhancement will make the output shortened urls non-sequential(cannot be guessed). It uses [hashids](https://hashids.org). To make sure that the new urls do not conflict with the previously generated urls, set the minimum length of the output url to be greater than highest length of the currently generated urls. It can be set using "hsahids.min.length" env var.

List of new env var:
1. hashids.salt
2. hsahids.min.length
