### PR TITLE
RAIN-1901: Allowed file with capital extension to upload in filestore - verion bump up and changelog

### DIFF
--- a/egov-filestore/CHANGELOG.md
+++ b/egov-filestore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 1.2.1 - 2021-01-15
+
+- Allowed file with capital extension to upload in filestore
+
+
 ## 1.2.0 - 2020-07-14
 
 - Added support for `minio` `S3` compatible client

--- a/egov-filestore/pom.xml
+++ b/egov-filestore/pom.xml
@@ -12,7 +12,7 @@
 	</parent>
 	<groupId>org.egov</groupId>
 	<artifactId>egov-filestore</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.1-SNAPSHOT</version>
 	<name>egov-filestore</name>
 	<description>eGov File store project for eGov services</description>
 	<properties>


### PR DESCRIPTION
RAIN-1901: Allowed file with capital extension to upload in filestore